### PR TITLE
Removing php 5.2~5.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,12 +5,6 @@ language: php
 php:
   # using major version aliases
 
-  # aliased to 5.2.17
-  - 5.2
-  # aliased to 5.3.29
-  - 5.3
-  # aliased to a recent 5.4.x version
-  - 5.4
   # aliased to a recent 5.5.x version
   - 5.5
   # aliased to a recent 5.6.x version
@@ -31,6 +25,7 @@ matrix:
     - php: hhvm
       env: DB=pgsql  # PDO driver for pgsql is unsupported by HHVM (3rd party install for support)
   allow_failures:
+    - php: 5.5
     - php: 7.0
     - php: hhvm
 


### PR DESCRIPTION
Removing old php version support.
Fix #1 